### PR TITLE
[DP-9231] - Add allow_deletions for branches

### DIFF
--- a/github/Branch.py
+++ b/github/Branch.py
@@ -121,6 +121,7 @@ class Branch(github.GithubObject.NonCompletableGithubObject):
         required_approving_review_count=github.GithubObject.NotSet,
         user_push_restrictions=github.GithubObject.NotSet,
         team_push_restrictions=github.GithubObject.NotSet,
+        allow_deletions=github.GithubObject.NotSet,
     ):
         """
         :calls: `PUT /repos/{owner}/{repo}/branches/{branch}/protection <https://docs.github.com/en/rest/reference/repos#get-branch-protection>`_
@@ -134,6 +135,7 @@ class Branch(github.GithubObject.NonCompletableGithubObject):
         :required_approving_review_count: int
         :user_push_restrictions: list of strings
         :team_push_restrictions: list of strings
+        :allow_deletions: bool
 
         NOTE: The GitHub API groups strict and contexts together, both must
         be submitted. Take care to pass both as arguments even if only one is
@@ -162,6 +164,9 @@ class Branch(github.GithubObject.NonCompletableGithubObject):
             required_approving_review_count is github.GithubObject.NotSet
             or isinstance(required_approving_review_count, int)
         ), (required_approving_review_count)
+        assert allow_deletions is github.GithubObject.NotSet or isinstance(
+            allow_deletions, bool
+        ), allow_deletions
 
         post_parameters = {}
         if (
@@ -235,6 +240,9 @@ class Branch(github.GithubObject.NonCompletableGithubObject):
             }
         else:
             post_parameters["restrictions"] = None
+
+        if allow_deletions is not github.GithubObject.NotSet:
+            post_parameters["allow_deletions"] = allow_deletions
 
         headers, data = self._requester.requestJsonAndCheck(
             "PUT",

--- a/github/BranchProtection.py
+++ b/github/BranchProtection.py
@@ -67,6 +67,14 @@ class BranchProtection(github.GithubObject.CompletableGithubObject):
         self._completeIfNotSet(self._required_pull_request_reviews)
         return self._required_pull_request_reviews.value
 
+    @property
+    def allow_deletions(self):
+        """
+        :type: bool
+        """
+        self._completeIfNotSet(self._allow_deletions)
+        return self._allow_deletions.value
+
     def get_user_push_restrictions(self):
         """
         :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.NamedUser.NamedUser`
@@ -97,6 +105,7 @@ class BranchProtection(github.GithubObject.CompletableGithubObject):
         self._required_pull_request_reviews = github.GithubObject.NotSet
         self._user_push_restrictions = github.GithubObject.NotSet
         self._team_push_restrictions = github.GithubObject.NotSet
+        self._allow_deletions = github.GithubObject.NotSet
 
     def _useAttributes(self, attributes):
         if "url" in attributes:  # pragma no branch
@@ -118,3 +127,7 @@ class BranchProtection(github.GithubObject.CompletableGithubObject):
         if "restrictions" in attributes:  # pragma no branch
             self._user_push_restrictions = attributes["restrictions"]["users_url"]
             self._team_push_restrictions = attributes["restrictions"]["teams_url"]
+        if "allow_deletions" in attributes: # pragma no branch
+            self._allow_deletions = self._makeBoolAttribute(
+                attributes["allow_deletions"]["enabled"]
+            )

--- a/github/BranchProtection.py
+++ b/github/BranchProtection.py
@@ -127,7 +127,7 @@ class BranchProtection(github.GithubObject.CompletableGithubObject):
         if "restrictions" in attributes:  # pragma no branch
             self._user_push_restrictions = attributes["restrictions"]["users_url"]
             self._team_push_restrictions = attributes["restrictions"]["teams_url"]
-        if "allow_deletions" in attributes: # pragma no branch
+        if "allow_deletions" in attributes:  # pragma no branch
             self._allow_deletions = self._makeBoolAttribute(
                 attributes["allow_deletions"]["enabled"]
             )

--- a/tests/Branch.py
+++ b/tests/Branch.py
@@ -62,6 +62,7 @@ class Branch(Framework.TestCase):
             strict=True,
             require_code_owner_reviews=True,
             required_approving_review_count=2,
+            allow_deletions=True,
         )
         branch_protection = self.protected_branch.get_protection()
         self.assertTrue(branch_protection.required_status_checks.strict)
@@ -76,6 +77,9 @@ class Branch(Framework.TestCase):
         self.assertEqual(
             branch_protection.required_pull_request_reviews.required_approving_review_count,
             2,
+        )
+        self.assertTrue(
+            branch_protection.allow_deletions
         )
 
     def testEditProtectionDismissalUsersWithUserOwnedBranch(self):

--- a/tests/ReplayData/Branch.testEditProtection.txt
+++ b/tests/ReplayData/Branch.testEditProtection.txt
@@ -4,7 +4,7 @@ api.github.com
 None
 /repos/jacquev6/PyGithub/branches/integrations/protection
 {'Authorization': 'Basic login_and_password_removed', 'Content-Type': 'application/json', 'User-Agent': 'PyGithub/Python', 'Accept': 'application/vnd.github.luke-cage-preview+json'}
-{"restrictions": null, "required_pull_request_reviews": {"require_code_owner_reviews": true, "required_approving_review_count": 2}, "required_status_checks": {"contexts": [], "strict": true}, "enforce_admins": null}
+{"restrictions": null, "required_pull_request_reviews": {"require_code_owner_reviews": true, "required_approving_review_count": 2}, "required_status_checks": {"contexts": [], "strict": true}, "enforce_admins": null, "allow_deletions": true}
 200
 [('status', '200 OK'), ('x-ratelimit-remaining', '4994'), ('content-length', '0'), ('server', 'nginx/1.0.13'), ('connection', 'keep-alive'), ('x-ratelimit-limit', '5000'), ('etag', '"e0dc2dfc56971f4a36de1216356ea98b"'), ('date', 'Sat, 05 May 2018 06:05:54 GMT'), ('content-type', 'application/json; charset=utf-8')]
 ''
@@ -18,5 +18,5 @@ None
 None
 200
 [('status', '200 OK'), ('x-ratelimit-remaining', '4994'), ('content-length', '0'), ('server', 'nginx/1.0.13'), ('connection', 'keep-alive'), ('x-ratelimit-limit', '5000'), ('etag', '"81ba94a48ad867b26d48c023ac584f43"'), ('date', 'Mon, 07 May 2018 13:42:41 GMT'), ('content-type', 'application/json; charset=utf-8')]
-{"url":"https://api.github.com/repos/jacquev6/PyGithub/branches/integrations/protection","required_pull_request_reviews":{"url":"https://api.github.com/repos/jacquev6/PyGithub/branches/integrations/protection/required_pull_request_reviews","dismiss_stale_reviews":false,"require_code_owner_reviews":true,"required_approving_review_count":2},"required_status_checks":{"url":"https://api.github.com/repos/jacquev6/PyGithub/branches/integrations/protection/required_status_checks","strict":true,"contexts":[],"contexts_url":"https://api.github.com/repos/jacquev6/PyGithub/branches/integrations/protection/required_status_checks/contexts"},"enforce_admins":{"url":"https://api.github.com/repos/jacquev6/PyGithub/branches/integrations/protection/enforce_admins","enabled":true}}
+{"url":"https://api.github.com/repos/jacquev6/PyGithub/branches/integrations/protection","required_pull_request_reviews":{"url":"https://api.github.com/repos/jacquev6/PyGithub/branches/integrations/protection/required_pull_request_reviews","dismiss_stale_reviews":false,"require_code_owner_reviews":true,"required_approving_review_count":2},"required_status_checks":{"url":"https://api.github.com/repos/jacquev6/PyGithub/branches/integrations/protection/required_status_checks","strict":true,"contexts":[],"contexts_url":"https://api.github.com/repos/jacquev6/PyGithub/branches/integrations/protection/required_status_checks/contexts"},"enforce_admins":{"url":"https://api.github.com/repos/jacquev6/PyGithub/branches/integrations/protection/enforce_admins","enabled":true}, "allow_deletions": {"enabled": true}}
 


### PR DESCRIPTION
Add the `allow_deletions` option for branch protections per the [github api](https://docs.github.com/en/rest/branches/branch-protection#update-branch-protection).

This is required so that [DP-9231] (which archives old doc branches) can successfully delete branches to be archived without disrupting existing branch protections.

[DP-9231]: https://confluentinc.atlassian.net/browse/DP-9231?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ